### PR TITLE
Remove dependency on `unstable/contract`.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,5 +1,5 @@
 #lang info
 (define version "1.0")
 (define collection "restore")
-(define deps '("base" "unstable-contract-lib"))
+(define deps '(("base" #:version "6.2.900.15") "unstable-lib"))
 (define build-deps '())

--- a/main.rkt
+++ b/main.rkt
@@ -2,8 +2,7 @@
 (require racket/match
          racket/tcp
          racket/contract/base
-         unstable/error
-         unstable/contract)
+         unstable/error)
 
 (define ENV-VAR #"RESTORE")
 


### PR DESCRIPTION
Most of the functionality of that library has been moved to `racket/contract`, and `unstable/contract` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2.1. To preserve compatibility, you can create a Racket 6.2.1-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-contract-lib` package, as it will not be part of the main distribution in future versions. If you decide to go with that option, please keep a dependency to `unstable-contract-lib`.
